### PR TITLE
Add product utilities and pytest suite

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,16 @@
 # paint-assistant
-paint-assistant
+
+Tools and datasets for exploring National Paints products.
+
+## Running tests
+
+The project uses [pytest](https://docs.pytest.org/) for automated testing. To
+run the test suite, install the project's Python dependencies (if any) and
+execute:
+
+```bash
+pytest
+```
+
+The tests exercise the JSON loading helpers and the validation utilities for
+detecting duplicate product codes.

--- a/paint_assistant.py
+++ b/paint_assistant.py
@@ -1,0 +1,107 @@
+"""Utilities for working with the National Paints product datasets."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Iterable, List, Mapping, MutableMapping
+
+# Paths to the JSON datasets distributed with the repository.
+BASE_DIR = Path(__file__).resolve().parent
+PRODUCTS_PATH = BASE_DIR / "paint_products.json"
+PRICELIST_PATH = BASE_DIR / "pricelistnationalpaints.json"
+
+
+def load_products(path: str | Path = PRODUCTS_PATH) -> list:
+    """Load the structured product data from :mod:`paint_products.json`.
+
+    Parameters
+    ----------
+    path:
+        Optional override for the file location. The default points to the copy
+        tracked in the repository.
+
+    Returns
+    -------
+    list
+        A nested list of dictionaries describing the available paint products.
+    """
+
+    path = Path(path)
+    with path.open(encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+def _iter_price_products(price_data: Mapping) -> Iterable[MutableMapping[str, object]]:
+    """Yield the product dictionaries from a price list payload."""
+
+    for category in price_data.get("product_categories", []):
+        for subcategory in category.get("subcategories", []):
+            yield from subcategory.get("products", [])
+
+
+def load_pricelist(path: str | Path = PRICELIST_PATH) -> Mapping[str, object]:
+    """Load the price list JSON document into a Python mapping."""
+
+    path = Path(path)
+    with path.open(encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+def get_price(product_code: str, size: str, *, price_data: Mapping[str, object] | None = None) -> float:
+    """Return the price for a product *code* and *size* combination.
+
+    Parameters
+    ----------
+    product_code:
+        The product code as listed in :mod:`pricelistnationalpaints.json`.
+    size:
+        The size entry to look up (for example, ``"18 Ltr (Drum)"``).
+    price_data:
+        Optionally provide a pre-loaded price list structure to avoid reloading
+        the JSON file for repeated lookups.
+
+    Raises
+    ------
+    KeyError
+        If the product code or size is not present in the dataset.
+    """
+
+    if price_data is None:
+        price_data = load_pricelist()
+
+    for product in _iter_price_products(price_data):
+        if product.get("product_code") != product_code:
+            continue
+        for entry in product.get("prices", []):
+            if entry.get("size") == size:
+                return float(entry["price"])
+        raise KeyError(f"Size {size!r} not found for product code {product_code!r}")
+
+    raise KeyError(f"Product code {product_code!r} not found in price list")
+
+
+def list_sizes(product_code: str, *, price_data: Mapping[str, object] | None = None) -> List[str]:
+    """Return the available package sizes for *product_code*.
+
+    Parameters
+    ----------
+    product_code:
+        The product code to search for in the price list.
+    price_data:
+        Optionally provide a pre-loaded price list structure to avoid reloading
+        the JSON file.
+
+    Raises
+    ------
+    KeyError
+        If the product code is not present in the dataset.
+    """
+
+    if price_data is None:
+        price_data = load_pricelist()
+
+    for product in _iter_price_products(price_data):
+        if product.get("product_code") == product_code:
+            return [entry.get("size", "") for entry in product.get("prices", [])]
+
+    raise KeyError(f"Product code {product_code!r} not found in price list")

--- a/tests/test_products.py
+++ b/tests/test_products.py
@@ -1,0 +1,42 @@
+import pytest
+
+import paint_assistant
+
+
+@pytest.fixture(scope="module")
+def price_data():
+    """Load the price list once for reuse across tests."""
+
+    return paint_assistant.load_pricelist()
+
+
+def test_load_products_parses_product_entries():
+    products = paint_assistant.load_products()
+
+    assert isinstance(products, list)
+    assert products, "No product data was returned"
+
+    # Extract the first dictionary entry to ensure the nested structure is intact.
+    first_entry = None
+    for group in products:
+        if isinstance(group, list) and group:
+            maybe_entry = group[0]
+            if isinstance(maybe_entry, dict):
+                first_entry = maybe_entry
+                break
+
+    assert first_entry is not None, "Expected at least one product entry"
+    assert "product_name" in first_entry
+    assert first_entry["product_name"], "Product name should not be empty"
+
+
+def test_get_price_returns_expected_value(price_data):
+    price = paint_assistant.get_price("A119", "18 Ltr (Drum)", price_data=price_data)
+
+    assert price == pytest.approx(80.0)
+
+
+def test_list_sizes_returns_known_sizes(price_data):
+    sizes = paint_assistant.list_sizes("A119", price_data=price_data)
+
+    assert sizes == ["18 Ltr (Drum)", "3.6 Ltr (Gallon)"]

--- a/tests/test_validate_codes.py
+++ b/tests/test_validate_codes.py
@@ -1,0 +1,8 @@
+import validate_codes
+
+
+def test_find_duplicate_codes_detects_a050_duplicate():
+    duplicates = validate_codes.find_duplicate_codes()
+
+    assert "A050" in duplicates
+    assert duplicates["A050"] == 2

--- a/validate_codes.py
+++ b/validate_codes.py
@@ -1,0 +1,42 @@
+"""Utility script to validate product codes in the price list dataset."""
+from __future__ import annotations
+
+from collections import Counter
+from pathlib import Path
+from typing import Dict, Iterable
+
+from paint_assistant import PRICELIST_PATH, _iter_price_products, load_pricelist
+
+
+def _collect_product_codes(price_data: dict) -> Iterable[str]:
+    """Yield all product codes from the price data structure."""
+
+    for product in _iter_price_products(price_data):
+        code = product.get("product_code")
+        if code:
+            yield code
+
+
+def find_duplicate_codes(path: str | Path = PRICELIST_PATH) -> Dict[str, int]:
+    """Return a mapping of duplicate product codes to their counts."""
+
+    price_data = load_pricelist(path)
+    counts = Counter(_collect_product_codes(price_data))
+    return {code: count for code, count in counts.items() if count > 1}
+
+
+def main() -> None:
+    """Print duplicate product codes, if any."""
+
+    duplicates = find_duplicate_codes()
+    if not duplicates:
+        print("No duplicate product codes found.")
+        return
+
+    print("Duplicate product codes detected:")
+    for code, count in sorted(duplicates.items()):
+        print(f"- {code}: {count} occurrences")
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
+    main()


### PR DESCRIPTION
## Summary
- add helper module for loading the product catalog and price list data
- add a validation script that flags duplicate product codes
- introduce pytest-based tests covering data parsing, pricing helpers, and duplicate detection
- document how to run the automated tests in the README

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c989375e348327a12ab11f1c9c9e62