### PR TITLE
Add CLI chatbot for paint product inquiries

### DIFF
--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,0 +1,1 @@
+"""Source package for the paint assistant chatbot."""

--- a/src/chatbot.py
+++ b/src/chatbot.py
@@ -1,0 +1,109 @@
+"""Command line chatbot for paint product information."""
+
+from __future__ import annotations
+
+import re
+
+try:  # pragma: no cover - allow running both as a module and as a script.
+    from .data.products import find_product_by_name, summarize_product
+    from .data.prices import list_available_sizes, lookup_price
+except ImportError:  # pragma: no cover - fallback for direct script execution.
+    from data.products import find_product_by_name, summarize_product  # type: ignore
+    from data.prices import list_available_sizes, lookup_price  # type: ignore
+
+
+_ABOUT_RE = re.compile(r"^\s*tell me about\s+(.+?)[\.!?]*\s*$", re.IGNORECASE)
+_PRICE_RE = re.compile(r"^\s*how much is\s+([A-Za-z0-9]+)\s+in\s+(.+?)[\.!?]*\s*$", re.IGNORECASE)
+
+
+def _handle_about(product_name: str) -> str:
+    product = find_product_by_name(product_name)
+    if not product:
+        return f"I couldn't find a product named \"{product_name.strip()}\"."
+
+    summary = summarize_product(product)
+    name = product.get("product_name", product_name).strip()
+    return f"{name}\n{summary}"
+
+
+def _handle_price(product_code: str, size: str) -> str:
+    product, price_entry, currency = lookup_price(product_code, size)
+    if product is None:
+        return f"I couldn't find a product with the code \"{product_code.strip()}\"."
+
+    if price_entry is None:
+        available_sizes = list_available_sizes(product_code)
+        if available_sizes:
+            choices = ", ".join(available_sizes)
+            return (
+                f"I couldn't find the size \"{size.strip()}\" for {product['product_name']} (code {product['product_code']}). "
+                f"Available sizes are: {choices}."
+            )
+        return f"I couldn't find size details for {product['product_name']} (code {product['product_code']})."
+
+    price_value = price_entry.get("price")
+    size_label = price_entry.get("size", size.strip())
+    if price_value is None:
+        return (
+            f"The price for {product['product_name']} (code {product['product_code']}) in {size_label} isn't listed."
+        )
+
+    formatted_price = f"{price_value:,.2f}"
+    currency_label = currency.strip()
+    if currency_label:
+        formatted_price = f"{formatted_price} {currency_label}"
+
+    return (
+        f"{product['product_name']} (code {product['product_code']}) costs {formatted_price} for {size_label}."
+    )
+
+
+def respond_to(message: str) -> str:
+    message = message.strip()
+    if not message:
+        return "Please enter a question about a product or its price."
+
+    about_match = _ABOUT_RE.match(message)
+    if about_match:
+        product_name = about_match.group(1)
+        return _handle_about(product_name)
+
+    price_match = _PRICE_RE.match(message)
+    if price_match:
+        product_code, size = price_match.groups()
+        return _handle_price(product_code, size)
+
+    return (
+        "I'm not sure how to help with that. Try asking 'Tell me about <product name>' or "
+        "'How much is <product code> in <size>?'."
+    )
+
+
+def run_cli() -> None:
+    print("Paint Assistant Chatbot")
+    print("Ask me about a product or a price. Type 'exit' or 'quit' to leave.\n")
+
+    while True:
+        try:
+            user_input = input("You: ")
+        except EOFError:
+            print()
+            break
+        except KeyboardInterrupt:
+            print("\nAssistant: Goodbye!")
+            return
+
+        if user_input.strip().lower() in {"exit", "quit"}:
+            print("Assistant: Goodbye!")
+            break
+
+        response = respond_to(user_input)
+        print(f"Assistant: {response}")
+
+
+def main() -> None:
+    run_cli()
+
+
+if __name__ == "__main__":
+    main()

--- a/src/data/__init__.py
+++ b/src/data/__init__.py
@@ -1,0 +1,1 @@
+"""Data access helpers for paint assistant."""

--- a/src/data/prices.py
+++ b/src/data/prices.py
@@ -1,0 +1,82 @@
+"""Utilities for accessing paint pricing information."""
+
+from __future__ import annotations
+
+import json
+from functools import lru_cache
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_PRICES_FILE = _REPO_ROOT / "pricelistnationalpaints.json"
+
+
+def _load_raw_prices() -> Dict[str, Any]:
+    with _PRICES_FILE.open(encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+@lru_cache(maxsize=1)
+def _prices_payload() -> Dict[str, Any]:
+    return _load_raw_prices()
+
+
+def _flatten_price_products(payload: Dict[str, Any]) -> List[Dict[str, Any]]:
+    products: List[Dict[str, Any]] = []
+    for category in payload.get("product_categories", []):
+        for subcategory in category.get("subcategories", []):
+            products.extend(subcategory.get("products", []))
+    return products
+
+
+@lru_cache(maxsize=1)
+def _products_by_code() -> Dict[str, Dict[str, Any]]:
+    return {
+        product["product_code"].upper(): product
+        for product in _flatten_price_products(_prices_payload())
+        if product.get("product_code")
+    }
+
+
+def get_currency() -> str:
+    return _prices_payload().get("currency", "")
+
+
+def get_product_by_code(code: str) -> Optional[Dict[str, Any]]:
+    if not code:
+        return None
+    return _products_by_code().get(code.strip().upper())
+
+
+def list_available_sizes(code: str) -> List[str]:
+    product = get_product_by_code(code)
+    if not product:
+        return []
+    return [price.get("size", "") for price in product.get("prices", []) if price.get("size")]
+
+
+def _normalize_size(value: str) -> str:
+    return " ".join(value.strip().lower().split())
+
+
+def lookup_price(code: str, size: str) -> Tuple[Optional[Dict[str, Any]], Optional[Dict[str, Any]], str]:
+    product = get_product_by_code(code)
+    currency = get_currency()
+    if not product:
+        return None, None, currency
+
+    normalized_size = _normalize_size(size) if size else ""
+    for price_entry in product.get("prices", []):
+        size_label = price_entry.get("size")
+        if size_label and _normalize_size(size_label) == normalized_size:
+            return product, price_entry, currency
+
+    return product, None, currency
+
+
+__all__ = [
+    "get_currency",
+    "get_product_by_code",
+    "list_available_sizes",
+    "lookup_price",
+]

--- a/src/data/products.py
+++ b/src/data/products.py
@@ -1,0 +1,123 @@
+"""Utilities for accessing paint product metadata."""
+
+from __future__ import annotations
+
+import json
+from functools import lru_cache
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+# Paths ---------------------------------------------------------------------
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_PRODUCTS_FILE = _REPO_ROOT / "paint_products.json"
+
+
+# Data loading ---------------------------------------------------------------
+
+def _load_raw_products() -> Any:
+    """Load the raw nested JSON payload for products."""
+    with _PRODUCTS_FILE.open(encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+def _flatten_products(payload: Any) -> List[Dict[str, Any]]:
+    """Flatten the nested payload into individual product dictionaries."""
+    products: List[Dict[str, Any]] = []
+    stack: List[Any] = [payload]
+    while stack:
+        current = stack.pop()
+        if isinstance(current, dict):
+            if "product_name" in current:
+                products.append(current)
+            for value in current.values():
+                stack.append(value)
+        elif isinstance(current, list):
+            stack.extend(current)
+    return products
+
+
+@lru_cache(maxsize=1)
+def get_all_products() -> List[Dict[str, Any]]:
+    """Return a list of all products defined in the dataset."""
+    return _flatten_products(_load_raw_products())
+
+
+# Helpers -------------------------------------------------------------------
+
+def _normalize_text(value: str) -> str:
+    return " ".join(value.strip().lower().split())
+
+
+def _stringify(value: Any) -> str:
+    if isinstance(value, str):
+        return " ".join(value.split())
+    if isinstance(value, list):
+        parts = [_stringify(item) for item in value if item]
+        return "; ".join(part for part in parts if part)
+    if isinstance(value, dict):
+        parts = []
+        for key, inner_value in value.items():
+            text = _stringify(inner_value)
+            if text:
+                nice_key = key.replace("_", " ").replace("-", " ").strip().capitalize()
+                parts.append(f"{nice_key}: {text}")
+        return "; ".join(parts)
+    return str(value)
+
+
+# Public API ----------------------------------------------------------------
+
+
+def find_product_by_name(name: str) -> Optional[Dict[str, Any]]:
+    """Return the product dictionary for *name* if available."""
+    if not name:
+        return None
+
+    normalized_query = _normalize_text(name)
+    products = get_all_products()
+
+    # First try exact match ignoring case and spacing differences.
+    for product in products:
+        if _normalize_text(product.get("product_name", "")) == normalized_query:
+            return product
+
+    # Fallback to partial match.
+    for product in products:
+        if normalized_query in _normalize_text(product.get("product_name", "")):
+            return product
+
+    return None
+
+
+def list_product_names() -> List[str]:
+    """Return all product names available in the dataset."""
+    return [product.get("product_name", "") for product in get_all_products() if product.get("product_name")]
+
+
+def summarize_product(product: Dict[str, Any]) -> str:
+    """Create a readable summary for a product dictionary."""
+    description = product.get("description") or product.get("product_description")
+    uses = product.get("uses") or product.get("usage") or product.get("usage_data")
+    advantages = product.get("advantages") or product.get("advantages_and_intended_use")
+
+    parts: List[str] = []
+    if description:
+        parts.append(_stringify(description))
+    if uses:
+        parts.append(f"Uses: {_stringify(uses)}")
+    if advantages:
+        parts.append(f"Advantages: {_stringify(advantages)}")
+
+    if not parts:
+        return "No summary is available for this product."
+
+    return "\n".join(parts)
+
+
+__all__ = [
+    "find_product_by_name",
+    "get_all_products",
+    "list_product_names",
+    "summarize_product",
+]


### PR DESCRIPTION
## Summary
- introduce a CLI chatbot that interprets “tell me about …” and “how much is …” prompts and responds with product descriptions or pricing details
- add data access helpers that load the bundled product and pricing JSON files, normalise lookups, and supply fallbacks for unknown products or sizes

## Testing
- python -m src.chatbot <<'EOF'
Tell me about NATIONAL NATURAL FURNITURE FILLER (NARI)
How much is A119 in 18 Ltr (Drum)?
How much is A119 in 1 Ltr?
Tell me about Unknown Product
How much is ZZZZ in 1 Ltr?
exit
EOF
- python -m compileall src

------
https://chatgpt.com/codex/tasks/task_e_68c9877d9b8c8327b538dd388568c2b5