### PR TITLE
Normalize prices with slash hyphen suffix

### DIFF
--- a/src/data/prices.py
+++ b/src/data/prices.py
@@ -33,7 +33,10 @@ def _normalize_price(value: object) -> float:
 
         cleaned = cleaned.lower().replace("aed", "")
         cleaned = cleaned.replace(",", "")
+        cleaned = re.sub(r"/-\s*$", "", cleaned)
+        cleaned = cleaned.strip()
         cleaned = re.sub(r"[^0-9.\-]", "", cleaned)
+        cleaned = cleaned.rstrip("-")
 
         if cleaned in {"", ".", "-", "-.", ".-"}:
             raise ValueError(f"Could not parse price value: {value!r}")

--- a/tests/test_prices.py
+++ b/tests/test_prices.py
@@ -1,0 +1,15 @@
+"""Tests for price normalization utilities."""
+
+from pathlib import Path
+import sys
+
+sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))
+
+from data.prices import _normalize_price
+
+
+def test_normalize_price_handles_trailing_slash_hyphen():
+    """Ensure price strings ending with '/-' normalize correctly."""
+
+    assert _normalize_price("78/-") == 78.0
+    assert _normalize_price("AED 78/-") == 78.0


### PR DESCRIPTION
## Summary
- update `_normalize_price` to trim trailing `/-` suffixes and dangling hyphens prior to float conversion
- add regression coverage for `78/-` and `AED 78/-` inputs

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ca603a009c832787a9d40a5e06df41