### PR TITLE
Refine duplicate code detection test

### DIFF
--- a/tests/test_validate_codes.py
+++ b/tests/test_validate_codes.py
@@ -1,8 +1,35 @@
 import validate_codes
 
 
-def test_find_duplicate_codes_detects_a050_duplicate():
-    duplicates = validate_codes.find_duplicate_codes()
+def test_find_duplicate_codes_uses_payload_from_monkeypatched_pricelist(monkeypatch):
+    """A synthetic payload should produce the expected duplicate mapping."""
 
-    assert "A050" in duplicates
-    assert duplicates["A050"] == 2
+    payload = {
+        "product_categories": [
+            {
+                "subcategories": [
+                    {
+                        "products": [
+                            {"product_code": "X001"},
+                            {"product_code": "DUP"},
+                            {"product_code": "DUP"},
+                            {"product_code": "X002"},
+                        ]
+                    }
+                ]
+            }
+        ]
+    }
+
+    def fake_load_pricelist(path=validate_codes.PRICELIST_PATH):  # pragma: no cover - exercised indirectly
+        return payload
+
+    monkeypatch.setattr(validate_codes, "load_pricelist", fake_load_pricelist)
+
+    assert validate_codes.find_duplicate_codes() == {"DUP": 2}
+
+
+def test_find_duplicate_codes_detects_no_duplicates_in_real_dataset():
+    """Ensure the bundled dataset still has no duplicate product codes."""
+
+    assert validate_codes.find_duplicate_codes() == {}


### PR DESCRIPTION
## Summary
- stub out `load_pricelist` in the duplicate-code test so it runs against a synthetic payload with a known duplicate
- assert the expected duplicate mapping and verify the real dataset currently contains no duplicates

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ca661c6e708327afe8d1c12bc8fd62