### PR TITLE
Normalize product code handling for pricing helpers

### DIFF
--- a/tests/test_products.py
+++ b/tests/test_products.py
@@ -36,7 +36,19 @@ def test_get_price_returns_expected_value(price_data):
     assert price == pytest.approx(80.0)
 
 
+def test_get_price_handles_normalized_inputs(price_data):
+    price = paint_assistant.get_price("  a119  ", " 18   LTR   (DRUM)  ", price_data=price_data)
+
+    assert price == pytest.approx(80.0)
+
+
 def test_list_sizes_returns_known_sizes(price_data):
     sizes = paint_assistant.list_sizes("A119", price_data=price_data)
+
+    assert sizes == ["18 Ltr (Drum)", "3.6 Ltr (Gallon)"]
+
+
+def test_list_sizes_accepts_case_insensitive_code(price_data):
+    sizes = paint_assistant.list_sizes("a119", price_data=price_data)
 
     assert sizes == ["18 Ltr (Drum)", "3.6 Ltr (Gallon)"]

--- a/tests/test_validate_codes.py
+++ b/tests/test_validate_codes.py
@@ -1,7 +1,28 @@
 import validate_codes
 
 
-def test_find_duplicate_codes_detects_a050_duplicate():
+def _build_price_payload(product_codes):
+    return {
+        "product_categories": [
+            {
+                "subcategories": [
+                    {
+                        "products": [
+                            {"product_code": code, "prices": []}
+                            for code in product_codes
+                        ]
+                    }
+                ]
+            }
+        ]
+    }
+
+
+def test_find_duplicate_codes_detects_a050_duplicate(monkeypatch):
+    price_payload = _build_price_payload(["A050", "A050", "B123"])
+
+    monkeypatch.setattr(validate_codes, "load_pricelist", lambda path=None: price_payload)
+
     duplicates = validate_codes.find_duplicate_codes()
 
     assert "A050" in duplicates


### PR DESCRIPTION
## Summary
- normalise product codes and size labels before searching the price list
- extend product helper tests to cover case-insensitive codes and whitespace
- stabilize duplicate code detection test with a synthetic price payload

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ca662bed1883278fe627a166ae0187