### PR TITLE
Normalize product code handling for duplicate detection

### DIFF
--- a/scripts/validate_codes.py
+++ b/scripts/validate_codes.py
@@ -9,6 +9,8 @@ from collections import Counter
 from pathlib import Path
 from typing import Iterable, List
 
+from paint_assistant import _normalize_product_code
+
 
 def iter_product_codes(data: dict) -> Iterable[str]:
     """Yield each product code from the nested price list structure."""
@@ -16,8 +18,10 @@ def iter_product_codes(data: dict) -> Iterable[str]:
         for subcategory in category.get("subcategories", []):
             for product in subcategory.get("products", []):
                 code = product.get("product_code")
-                if code is not None:
-                    yield code
+                if isinstance(code, str):
+                    normalized = _normalize_product_code(code)
+                    if normalized:
+                        yield normalized
 
 
 def load_codes(file_path: Path) -> List[str]:

--- a/tests/test_validate_codes.py
+++ b/tests/test_validate_codes.py
@@ -28,6 +28,16 @@ def test_find_duplicate_codes_detects_a050_duplicate(monkeypatch):
     assert duplicates == {"A050": 2}
 
 
+def test_find_duplicate_codes_normalizes_product_codes(monkeypatch):
+    price_payload = _build_price_payload(["A050", " a050 ", "B123"])
+
+    monkeypatch.setattr(validate_codes, "load_pricelist", lambda path=None: price_payload)
+
+    duplicates = validate_codes.find_duplicate_codes()
+
+    assert duplicates == {"A050": 2}
+
+
 def test_find_duplicate_codes_uses_payload_from_monkeypatched_pricelist(monkeypatch):
     """A synthetic payload should produce the expected duplicate mapping."""
 

--- a/validate_codes.py
+++ b/validate_codes.py
@@ -5,7 +5,12 @@ from collections import Counter
 from pathlib import Path
 from typing import Dict, Iterable
 
-from paint_assistant import PRICELIST_PATH, _iter_price_products, load_pricelist
+from paint_assistant import (
+    PRICELIST_PATH,
+    _iter_price_products,
+    _normalize_product_code,
+    load_pricelist,
+)
 
 
 def _collect_product_codes(price_data: dict) -> Iterable[str]:
@@ -13,8 +18,10 @@ def _collect_product_codes(price_data: dict) -> Iterable[str]:
 
     for product in _iter_price_products(price_data):
         code = product.get("product_code")
-        if code:
-            yield code
+        if isinstance(code, str):
+            normalized = _normalize_product_code(code)
+            if normalized:
+                yield normalized
 
 
 def find_duplicate_codes(path: str | Path = PRICELIST_PATH) -> Dict[str, int]:


### PR DESCRIPTION
## Summary
- normalize product codes in the library duplicate collector using the shared helper
- update the CLI validator to normalize codes the same way for consistent output
- add a regression test ensuring differently cased/whitespace codes are treated as a single duplicate

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cae16c64808327802b6a53b8c6c66d