### PR TITLE
Fix validate_codes import path

### DIFF
--- a/scripts/validate_codes.py
+++ b/scripts/validate_codes.py
@@ -5,9 +5,12 @@ from __future__ import annotations
 
 import argparse
 import json
+import sys
 from collections import Counter
 from pathlib import Path
 from typing import Iterable, List
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 from paint_assistant import _normalize_product_code
 


### PR DESCRIPTION
## Summary
- ensure scripts/validate_codes.py adds the repository root to sys.path before importing paint_assistant

## Testing
- python scripts/validate_codes.py


------
https://chatgpt.com/codex/tasks/task_e_68cbe43f91008327bfbcdf714d0e2bb6