### PR TITLE
Normalize hyphen variants in size keys

### DIFF
--- a/src/data/prices.py
+++ b/src/data/prices.py
@@ -9,6 +9,13 @@ from typing import Dict, List, Optional
 
 _PRICE_DATA: Dict[str, Dict[str, object]] | None = None
 
+_DASH_TRANSLATION = str.maketrans(
+    {
+        "\u2013": "-",  # en dash
+        "\u2014": "-",  # em dash
+    }
+)
+
 
 def _price_list_path() -> Path:
     """Return the path to the bundled National Paints price list JSON."""
@@ -51,7 +58,10 @@ def _normalize_price(value: object) -> float:
 
 def _normalize_size_key(size: object) -> str:
     """Create a canonical key for a size label."""
-    text = str(size or "").strip().lower()
+
+    text = str(size or "")
+    text = text.translate(_DASH_TRANSLATION)
+    text = text.strip().lower()
     return re.sub(r"\s+", " ", text)
 
 

--- a/tests/test_prices.py
+++ b/tests/test_prices.py
@@ -33,3 +33,9 @@ def test_get_price_handles_variant_only_product():
 
     assert get_price("A015", "White – 18 Ltr (Drum)") == 60.0
     assert get_price("a015", "APS – 3.6 Ltr (Gallon)") == 23.0
+
+
+def test_get_price_normalizes_standard_hyphen():
+    """Regular hyphen usage still matches sizes stored with typographic dashes."""
+
+    assert get_price("A015", "White - 18 Ltr (Drum)") == 60.0


### PR DESCRIPTION
## Summary
- normalize en/em dashes in size keys prior to lookups
- ensure get_price tolerates standard hyphens via regression test

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cbe72dfd8883278fb91cccd6fafddc