### PR TITLE
Add AI chat endpoint and retrieval pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ The project exposes the chatbot through a small FastAPI application. Install
 the runtime dependencies and launch the ASGI server with
 
 ```bash
-pip install fastapi uvicorn
+pip install -r requirements.txt
 uvicorn app.main:app --reload
 ```
 
@@ -18,6 +18,8 @@ The server provides two endpoints:
   service is ready.
 - `POST /chat` – accepts a JSON body with a `prompt` field and returns the
   chatbot's response as `{"response": "..."}`.
+- `POST /ai/chat` – enhanced assistant that supplements answers with retrieval
+  and tool data.
 
 Example usage with `curl`:
 
@@ -33,15 +35,50 @@ The response will contain the assistant's answer:
 {"response": "NP Colorant..."}
 ```
 
+## AI-powered chat endpoint
+
+The `/ai/chat` endpoint combines retrieval-augmented context with price and
+product lookup tools before handing the prompt to an LLM. To try it locally:
+
+1. Install dependencies listed in `requirements.txt`.
+2. Build the retrieval index:
+
+   ```bash
+   python -m src.rag.build_index
+   ```
+
+3. Export your OpenAI API key so the LLM backend can authenticate:
+
+   ```bash
+   export OPENAI_API_KEY="sk-your-api-key"
+   ```
+
+4. Start Uvicorn as shown above and issue a request:
+
+   ```bash
+   curl -X POST "http://127.0.0.1:8000/ai/chat" \
+     -H "Content-Type: application/json" \
+     -d '{"prompt": "How much is A119 in 18 Ltr (Drum)?"}'
+   ```
+
+   The response includes the model's reply, tool payloads, and retrieved
+   passages used to craft the answer.
+
 ## Running tests
 
 The project uses [pytest](https://docs.pytest.org/) for automated testing. To
 run the test suite, install the project's Python dependencies (if any) and
-execute:
+execute the legacy tests with:
 
 ```bash
-pytest
+pytest tests
 ```
 
-The tests exercise the JSON loading helpers and the validation utilities for
-detecting duplicate product codes.
+To exercise both the legacy checks and the AI chat scenarios run:
+
+```bash
+pytest tests tests_ai
+```
+
+The tests cover JSON loading helpers, validation utilities for detecting
+duplicate product codes, and integration points for the AI-powered endpoint.

--- a/app/ai_routes.py
+++ b/app/ai_routes.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+import re
+from typing import Any
+
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel, Field
+
+from src.chatbot import parse_price_prompt
+from src.models.llm import generate_answer
+from src.rag import RetrievedChunk, RetrievalPipeline
+from src.tools.paint import price_lookup_tool, product_card_tool
+
+router = APIRouter(prefix="/ai", tags=["AI Chat"])
+
+_ABOUT_RE = re.compile(r"tell me about\s+(.+?)[.?!]*$", re.IGNORECASE)
+_PIPELINE: RetrievalPipeline | None = None
+
+
+class AIChatRequest(BaseModel):
+    prompt: str = Field(min_length=1, description="End-user message")
+
+
+class AIChatResponse(BaseModel):
+    reply: str
+    used_tools: list[dict[str, Any]] = Field(default_factory=list)
+    retrieved: list[dict[str, Any]] = Field(default_factory=list)
+
+
+def _get_pipeline() -> RetrievalPipeline:
+    global _PIPELINE
+    if _PIPELINE is None:
+        _PIPELINE = RetrievalPipeline()
+    return _PIPELINE
+
+
+def _format_retrieved(chunks: list[RetrievedChunk]) -> list[dict[str, Any]]:
+    payloads: list[dict[str, Any]] = []
+    for chunk in chunks:
+        payloads.append(
+            {
+                "text": chunk.text,
+                "score": chunk.score,
+                "metadata": chunk.metadata,
+            }
+        )
+    return payloads
+
+
+def _gather_tools(prompt: str) -> list[dict[str, Any]]:
+    tools: list[dict[str, Any]] = []
+    price_args = parse_price_prompt(prompt)
+    card_identifier: str | None = None
+
+    if price_args:
+        code, size = price_args
+        price_payload = price_lookup_tool(code, size)
+        tools.append(price_payload)
+        card_identifier = (
+            price_payload.get("product_name")
+            or price_payload.get("requested_code")
+            or code
+        )
+
+    about_match = _ABOUT_RE.search(prompt)
+    if about_match:
+        card_identifier = about_match.group(1).strip()
+
+    if card_identifier:
+        card_payload = product_card_tool(card_identifier)
+        tools.append(card_payload)
+
+    return tools
+
+
+@router.post("/chat", response_model=AIChatResponse)
+async def ai_chat(request: AIChatRequest) -> AIChatResponse:
+    prompt = request.prompt.strip()
+    if not prompt:
+        raise HTTPException(status_code=400, detail="Prompt must not be empty.")
+
+    tools = _gather_tools(prompt)
+
+    try:
+        pipeline = _get_pipeline()
+        contexts = pipeline.get_contexts(prompt)
+    except FileNotFoundError as exc:
+        raise HTTPException(status_code=503, detail=str(exc)) from exc
+
+    try:
+        reply = generate_answer(prompt, contexts=contexts, tools=tools)
+    except RuntimeError as exc:
+        raise HTTPException(status_code=503, detail=str(exc)) from exc
+
+    return AIChatResponse(
+        reply=reply,
+        used_tools=tools,
+        retrieved=_format_retrieved(contexts),
+    )

--- a/app/main.py
+++ b/app/main.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from fastapi import FastAPI
 from pydantic import BaseModel
 
+from app.ai_routes import router as ai_router
 from src.chatbot import respond_to
 
 
@@ -21,6 +22,7 @@ class ChatResponse(BaseModel):
 
 
 app = FastAPI(title="Paint Assistant API", version="1.0.0")
+app.include_router(ai_router)
 
 
 @app.get("/health", tags=["Health"])

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+fastapi>=0.109
+uvicorn[standard]>=0.23
+pydantic>=2.0
+openai>=1.0

--- a/src/chatbot.py
+++ b/src/chatbot.py
@@ -140,6 +140,18 @@ def _parse_price_query(message: str, config: ChatbotConfig) -> Optional[Tuple[st
     return None
 
 
+def parse_price_prompt(
+    message: str,
+    *,
+    config: Optional[ChatbotConfig] = None,
+) -> Optional[Tuple[str, str]]:
+    """Return (code, size) when the prompt looks like a price query."""
+
+    if config is None:
+        config = DEFAULT_CONFIG
+    return _parse_price_query(message, config)
+
+
 def _handle_about(product_name: str) -> str:
     product = find_product_by_name(product_name)
     if not product:
@@ -234,3 +246,6 @@ def main() -> None:
 
 if __name__ == "__main__":
     main()
+
+
+__all__ = ["respond_to", "run_cli", "parse_price_prompt", "main"]

--- a/src/models/__init__.py
+++ b/src/models/__init__.py
@@ -1,0 +1,5 @@
+"""Model integration helpers for the paint assistant."""
+
+from .llm import generate_answer
+
+__all__ = ["generate_answer"]

--- a/src/models/llm.py
+++ b/src/models/llm.py
@@ -1,0 +1,172 @@
+"""Interface with large language models for the AI chat endpoint."""
+
+from __future__ import annotations
+
+import json
+import os
+from typing import Any, Dict, List, Sequence
+
+from ..rag import RetrievedChunk
+
+try:  # pragma: no cover - optional dependency
+    from openai import OpenAI  # type: ignore
+except ModuleNotFoundError:  # pragma: no cover - support environments without OpenAI SDK
+    OpenAI = None  # type: ignore[misc,assignment]
+
+try:  # pragma: no cover - optional dependency
+    import openai  # type: ignore
+except ModuleNotFoundError:  # pragma: no cover - optional dependency
+    openai = None  # type: ignore[misc,assignment]
+
+_DEFAULT_MODEL = "gpt-3.5-turbo"
+
+
+def _format_tools(tools: Sequence[Dict[str, Any]]) -> str:
+    formatted = []
+    for tool in tools:
+        name = tool.get("tool", "unknown")
+        formatted.append(f"- {name}: {json.dumps(tool, ensure_ascii=False, sort_keys=True)}")
+    return "\n".join(formatted)
+
+
+def _format_contexts(contexts: Sequence[RetrievedChunk]) -> str:
+    formatted = []
+    for chunk in contexts[:10]:
+        snippet = chunk.text.strip().replace("\n", " ")
+        metadata = json.dumps(chunk.metadata, ensure_ascii=False, sort_keys=True)
+        formatted.append(f"- score={chunk.score:.3f} {snippet} | metadata={metadata}")
+    return "\n".join(formatted)
+
+
+def _build_messages(prompt: str, contexts: Sequence[RetrievedChunk], tools: Sequence[Dict[str, Any]]):
+    instructions = (
+        "You are Paint Assistant, a helpful expert on National Paints products. "
+        "Use the provided tool results and reference documents to answer the user question."
+    )
+
+    details: List[str] = []
+    if tools:
+        details.append("Tool outputs:\n" + _format_tools(tools))
+    if contexts:
+        details.append("Retrieved documents:\n" + _format_contexts(contexts))
+    details.append(f"User question: {prompt}")
+
+    return [
+        {"role": "system", "content": instructions},
+        {"role": "user", "content": "\n\n".join(details)},
+    ]
+
+
+def _compose_prompt(prompt: str, contexts: Sequence[RetrievedChunk], tools: Sequence[Dict[str, Any]]) -> str:
+    payload = {
+        "prompt": prompt,
+        "tools": tools,
+        "contexts": [
+            {
+                "text": chunk.text,
+                "score": chunk.score,
+                "metadata": chunk.metadata,
+            }
+            for chunk in contexts
+        ],
+    }
+    return json.dumps(payload, ensure_ascii=False)
+
+
+def _format_price(tool: Dict[str, Any]) -> str:
+    price = tool.get("price")
+    if isinstance(price, (int, float)):
+        price_value = f"{price:,.2f}"
+    else:
+        price_value = str(price)
+    currency = tool.get("currency") or ""
+    size = tool.get("size") or tool.get("requested_size")
+    product_name = tool.get("product_name") or tool.get("requested_code") or "the product"
+    if currency:
+        return f"{product_name} costs {price_value} {currency} for {size}."
+    return f"{product_name} costs {price_value} for {size}."
+
+
+def _fallback_answer(prompt: str, contexts: Sequence[RetrievedChunk], tools: Sequence[Dict[str, Any]]) -> str:
+    parts: List[str] = []
+    for tool in tools:
+        if tool.get("tool") == "price_lookup" and tool.get("found"):
+            parts.append(_format_price(tool))
+        elif tool.get("tool") == "product_card" and tool.get("found") and tool.get("summary"):
+            parts.append(str(tool.get("summary")))
+
+    if not parts and contexts:
+        parts.append(contexts[0].text)
+
+    if not parts:
+        parts.append(
+            "I'm unable to reach the language model right now, but I'm still here to help. "
+            "Please try again in a moment."
+        )
+
+    if prompt:
+        parts.append(f"(Original question: {prompt})")
+
+    return "\n\n".join(parts)
+
+
+def generate_answer(
+    prompt: str,
+    *,
+    contexts: Sequence[RetrievedChunk],
+    tools: Sequence[Dict[str, Any]],
+) -> str:
+    """Generate a response using the available LLM backend or fall back gracefully."""
+
+    api_key = os.getenv("OPENAI_API_KEY")
+    messages = _build_messages(prompt, contexts, tools)
+
+    if OpenAI is not None and api_key:
+        client = OpenAI(api_key=api_key)
+        try:  # pragma: no cover - requires networked OpenAI access
+            completion = client.chat.completions.create(
+                model=_DEFAULT_MODEL,
+                messages=messages,
+            )
+        except AttributeError:  # pragma: no cover - support newer SDK variants
+            try:
+                response = client.responses.create(  # type: ignore[attr-defined]
+                    model=_DEFAULT_MODEL,
+                    input=_compose_prompt(prompt, contexts, tools),
+                )
+            except Exception as exc:  # pragma: no cover - network errors
+                raise RuntimeError("Failed to generate response from OpenAI API") from exc
+            else:
+                for item in getattr(response, "output", []):
+                    if getattr(item, "type", "") == "message":
+                        text_parts = [
+                            getattr(content, "text", "")
+                            for content in getattr(item, "content", [])
+                            if getattr(content, "type", "") == "text"
+                        ]
+                        text = "".join(text_parts).strip()
+                        if text:
+                            return text
+        else:
+            try:
+                text = completion.choices[0].message.content
+            except (IndexError, AttributeError, KeyError):  # pragma: no cover - SDK variations
+                text = None
+            if text:
+                return text.strip()
+
+    if openai is not None and api_key:
+        openai.api_key = api_key
+        try:  # pragma: no cover - requires OpenAI SDK v0 compatibility
+            completion = openai.ChatCompletion.create(model=_DEFAULT_MODEL, messages=messages)
+        except Exception as exc:  # pragma: no cover - propagate as runtime error
+            raise RuntimeError("Failed to generate response from OpenAI API") from exc
+        else:
+            message = completion["choices"][0]["message"].get("content")
+            if message:
+                return str(message).strip()
+
+    return _fallback_answer(prompt, contexts, tools)
+
+
+__all__ = ["generate_answer"]

--- a/src/rag/__init__.py
+++ b/src/rag/__init__.py
@@ -1,0 +1,106 @@
+"""Lightweight retrieval helpers used by the AI chat endpoint."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, List, Sequence
+
+from .build_index import DEFAULT_INDEX_PATH
+
+
+@dataclass
+class RetrievedChunk:
+    """Represents a piece of context retrieved for a query."""
+
+    text: str
+    score: float
+    metadata: Dict[str, Any]
+
+
+def _normalise_text(value: str) -> str:
+    return " ".join(value.lower().split())
+
+
+class RetrievalPipeline:
+    """Simple retriever that scores pre-built text chunks."""
+
+    def __init__(self, *, index_path: Path | None = None) -> None:
+        path = index_path or DEFAULT_INDEX_PATH
+        if not path.exists():
+            raise FileNotFoundError(
+                "Retrieval index not found. Run 'python -m src.rag.build_index' first."
+            )
+
+        with path.open(encoding="utf-8") as handle:
+            payload = json.load(handle)
+
+        self._records: List[Dict[str, Any]] = []
+        for entry in payload:
+            if not isinstance(entry, dict):
+                continue
+            text = str(entry.get("text", ""))
+            metadata = entry.get("metadata")
+            if not isinstance(metadata, dict):
+                metadata = {}
+            self._records.append({"text": text, "metadata": dict(metadata)})
+
+    @staticmethod
+    def _score_text(text: str, tokens: Sequence[str]) -> float:
+        lowered = text.lower()
+        score = 0.0
+        for token in tokens:
+            if not token:
+                continue
+            occurrences = lowered.count(token)
+            if occurrences:
+                score += float(occurrences)
+        return score
+
+    def get_contexts(
+        self,
+        query: str,
+        *,
+        top_k: int = 18,
+        rerank_k: int = 5,
+    ) -> List[RetrievedChunk]:
+        """Return the highest scoring chunks for *query*."""
+
+        del rerank_k  # The pipeline is intentionally simple for now.
+
+        tokens = [token for token in _normalise_text(query).split() if token]
+        if not tokens:
+            return []
+
+        ranked: List[RetrievedChunk] = []
+        for record in self._records:
+            text = record.get("text", "")
+            metadata = record.get("metadata", {})
+            score = self._score_text(text, tokens)
+            if score <= 0:
+                continue
+            ranked.append(
+                RetrievedChunk(
+                    text=text,
+                    score=score,
+                    metadata=dict(metadata),
+                )
+            )
+
+        if not ranked:
+            # Fall back to the first few records to provide context even without matches.
+            for record in self._records[:top_k]:
+                ranked.append(
+                    RetrievedChunk(
+                        text=record.get("text", ""),
+                        score=0.0,
+                        metadata=dict(record.get("metadata", {})),
+                    )
+                )
+
+        ranked.sort(key=lambda chunk: chunk.score, reverse=True)
+        return ranked[:top_k]
+
+
+__all__ = ["RetrievedChunk", "RetrievalPipeline", "DEFAULT_INDEX_PATH"]

--- a/src/rag/build_index.py
+++ b/src/rag/build_index.py
@@ -1,0 +1,66 @@
+"""Build a lightweight retrieval index for the AI chat endpoint."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Dict, List
+
+from ..data.products import get_all_products, summarize_product
+
+INDEX_FILENAME = "rag_index.json"
+DEFAULT_INDEX_PATH = Path(__file__).resolve().parents[2] / INDEX_FILENAME
+
+
+def _serialise_product(product: Dict[str, Any]) -> Dict[str, Any]:
+    name = str(product.get("product_name", "")).strip()
+    code = str(product.get("product_code", "")).strip()
+    summary = summarize_product(product)
+
+    text_parts: List[str] = []
+    if name:
+        text_parts.append(name)
+    if code:
+        text_parts.append(f"(code {code})")
+    if summary:
+        text_parts.append(summary)
+
+    metadata: Dict[str, Any] = {
+        "product_name": name,
+    }
+    if code:
+        metadata["product_code"] = code
+    category = product.get("category") or product.get("product_category")
+    if category:
+        metadata["category"] = category
+
+    return {
+        "text": " ".join(text_parts).strip(),
+        "metadata": metadata,
+    }
+
+
+def build_index(output_path: Path | None = None) -> Path:
+    """Generate the retrieval index file and return its path."""
+
+    path = output_path or DEFAULT_INDEX_PATH
+    products = get_all_products()
+    records = [_serialise_product(product) for product in products]
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8") as handle:
+        json.dump(records, handle, ensure_ascii=False, indent=2)
+
+    return path
+
+
+def main() -> None:
+    path = build_index()
+    print(f"Retrieval index written to {path}")
+
+
+if __name__ == "__main__":  # pragma: no cover - manual usage script
+    main()
+
+
+__all__ = ["DEFAULT_INDEX_PATH", "build_index", "main"]

--- a/src/tools/__init__.py
+++ b/src/tools/__init__.py
@@ -1,0 +1,5 @@
+"""Utility tools used by the AI assistant."""
+
+from .paint import price_lookup_tool, product_card_tool
+
+__all__ = ["price_lookup_tool", "product_card_tool"]

--- a/src/tools/paint.py
+++ b/src/tools/paint.py
@@ -1,0 +1,84 @@
+"""Tools that expose product and pricing data as structured payloads."""
+
+from __future__ import annotations
+
+from typing import Any, Dict
+
+from ..data.products import find_product_by_name, summarize_product
+from ..data.prices import get_product_by_code, list_available_sizes, lookup_price
+
+
+def price_lookup_tool(code: str, size: str) -> Dict[str, Any]:
+    """Return a structured payload describing the price lookup result."""
+
+    cleaned_code = code.strip()
+    cleaned_size = size.strip()
+
+    payload: Dict[str, Any] = {
+        "tool": "price_lookup",
+        "requested_code": cleaned_code,
+        "requested_size": cleaned_size,
+        "found": False,
+    }
+
+    product, price_entry, currency = lookup_price(cleaned_code, cleaned_size)
+    payload["currency"] = currency
+
+    if product:
+        payload["product_name"] = product.get("product_name")
+        payload["product_code"] = product.get("product_code")
+
+    if price_entry:
+        payload["found"] = True
+        payload["price"] = price_entry.get("price")
+        payload["size"] = price_entry.get("size", cleaned_size)
+    elif product:
+        code_to_query = product.get("product_code") or cleaned_code
+        payload["available_sizes"] = list_available_sizes(code_to_query)
+
+    return payload
+
+
+def product_card_tool(identifier: str) -> Dict[str, Any]:
+    """Return metadata useful for rendering a product card."""
+
+    query = identifier.strip()
+    payload: Dict[str, Any] = {
+        "tool": "product_card",
+        "identifier": query,
+        "found": False,
+    }
+
+    if not query:
+        return payload
+
+    product = find_product_by_name(query)
+    price_product = None
+    if not product:
+        price_product = get_product_by_code(query)
+        if price_product:
+            product = price_product
+    else:
+        price_product = get_product_by_code(product.get("product_code", ""))
+
+    if not product:
+        return payload
+
+    payload["found"] = True
+    payload["product_name"] = product.get("product_name") or product.get("productName")
+    product_code = product.get("product_code") or query
+    payload["product_code"] = product_code
+
+    summary = summarize_product(product) if product else ""
+    if not summary and price_product:
+        summary = price_product.get("product_description", "")
+    if summary:
+        payload["summary"] = summary
+
+    if product_code:
+        payload["available_sizes"] = list_available_sizes(product_code)
+
+    return payload
+
+
+__all__ = ["price_lookup_tool", "product_card_tool"]

--- a/tests_ai/test_ai_chat.py
+++ b/tests_ai/test_ai_chat.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+import pytest
+
+try:
+    from fastapi.testclient import TestClient
+except ModuleNotFoundError:  # pragma: no cover - FastAPI optional in CI
+    TestClient = None  # type: ignore[misc]
+else:
+    from app.main import app
+
+    client = TestClient(app)
+
+
+@pytest.mark.skipif(TestClient is None, reason="FastAPI is not installed")
+def test_ai_chat_price_lookup(monkeypatch):
+    from app import ai_routes
+
+    class DummyPipeline:
+        def get_contexts(self, query: str, *, top_k: int = 18, rerank_k: int = 5):
+            assert query
+            return []
+
+    monkeypatch.setattr(ai_routes, "_PIPELINE", DummyPipeline())
+
+    def fake_generate_answer(query: str, *, contexts, tools):
+        assert contexts == []
+        assert any(tool.get("tool") == "price_lookup" for tool in tools)
+        return "Stubbed AI response."
+
+    monkeypatch.setattr(ai_routes, "generate_answer", fake_generate_answer)
+
+    response = client.post(
+        "/ai/chat",
+        json={"prompt": "How much is A119 in 18 Ltr (Drum)?"},
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["reply"] == "Stubbed AI response."
+    price_tool = next(tool for tool in payload["used_tools"] if tool["tool"] == "price_lookup")
+    assert price_tool["found"] is True
+    assert price_tool["price"] == 80.0
+    assert price_tool["currency"] == "AED"
+
+
+@pytest.mark.skipif(TestClient is None, reason="FastAPI is not installed")
+def test_ai_chat_rejects_empty_prompt(monkeypatch):
+    from app import ai_routes
+
+    class DummyPipeline:
+        def get_contexts(self, query: str, *, top_k: int = 18, rerank_k: int = 5):
+            return []
+
+    monkeypatch.setattr(ai_routes, "_PIPELINE", DummyPipeline())
+    monkeypatch.setattr(ai_routes, "generate_answer", lambda *args, **kwargs: "unused")
+
+    response = client.post("/ai/chat", json={"prompt": "   "})
+    assert response.status_code == 400
+    assert response.json()["detail"] == "Prompt must not be empty."


### PR DESCRIPTION
## Summary
- expose the chatbot's price prompt parser for reuse and export it from the module
- add an AI chat FastAPI router backed by retrieval and tool integrations, plus supporting modules and utilities
- document the AI workflow, add dependency requirements, and create AI-focused tests

## Testing
- pytest tests tests_ai

------
https://chatgpt.com/codex/tasks/task_e_68cc5027b6cc832788ac77a571538958