### PR TITLE
Handle wrapped product codes in chatbot parsing

### DIFF
--- a/tests/test_chatbot.py
+++ b/tests/test_chatbot.py
@@ -62,6 +62,15 @@ def test_respond_to_price_lookup_with_code_fillers(prompt: str) -> None:
     assert response == expected
 
 
+def test_respond_to_price_lookup_with_wrapped_code() -> None:
+    prompt = "How much is the price of code (A119) in 18 Ltr (Drum)?"
+    expected = "National Acrylic Primer (W.B.) (code A119) costs 80.00 AED for 18 Ltr (Drum)."
+
+    response = respond_to(prompt)
+
+    assert response == expected
+
+
 def test_respond_to_price_unknown_size() -> None:
     response = respond_to("How much is A119 in 1 Ltr?")
 


### PR DESCRIPTION
## Summary
- extend product code token cleaning to strip common wrapping punctuation before lookup
- ensure code extraction paths reuse the improved helper so cleaned codes are returned
- add a regression test covering price queries where the code is wrapped in parentheses

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cce86edfdc83278ef9254b3b722f05