### PR TITLE
Ensure legacy OpenAI fallback works without v1 client

### DIFF
--- a/src/models/llm.py
+++ b/src/models/llm.py
@@ -10,7 +10,7 @@ from ..rag import RetrievedChunk
 
 try:  # pragma: no cover - optional dependency
     from openai import OpenAI  # type: ignore
-except ModuleNotFoundError:  # pragma: no cover - support environments without OpenAI SDK
+except ImportError:  # pragma: no cover - support environments without OpenAI SDK
     OpenAI = None  # type: ignore[misc,assignment]
 
 try:  # pragma: no cover - optional dependency


### PR DESCRIPTION
## Summary
- broaden the OpenAI import guard to handle ImportError when the v1 client is unavailable
- add a regression test that verifies generate_answer falls back to the legacy ChatCompletion client when only the legacy SDK is present

## Testing
- pytest tests_ai/test_ai_chat.py

------
https://chatgpt.com/codex/tasks/task_e_68cce87007bc8327901f4ef1b321ddf9