### PR TITLE
Improve price lookup tool input validation

### DIFF
--- a/src/tools/paint.py
+++ b/src/tools/paint.py
@@ -2,10 +2,15 @@
 
 from __future__ import annotations
 
-from typing import Any, Dict
+from typing import Any, Dict, List
 
 from ..data.products import find_product_by_name, summarize_product
-from ..data.prices import get_product_by_code, list_available_sizes, lookup_price
+from ..data.prices import (
+    get_currency,
+    get_product_by_code,
+    list_available_sizes,
+    lookup_price,
+)
 
 
 def price_lookup_tool(code: str, size: str) -> Dict[str, Any]:
@@ -14,6 +19,12 @@ def price_lookup_tool(code: str, size: str) -> Dict[str, Any]:
     cleaned_code = code.strip()
     cleaned_size = size.strip()
 
+    missing_fields: List[str] = []
+    if not cleaned_code:
+        missing_fields.append("code")
+    if not cleaned_size:
+        missing_fields.append("size")
+
     payload: Dict[str, Any] = {
         "tool": "price_lookup",
         "requested_code": cleaned_code,
@@ -21,8 +32,15 @@ def price_lookup_tool(code: str, size: str) -> Dict[str, Any]:
         "found": False,
     }
 
+    if "code" in missing_fields:
+        payload["currency"] = get_currency()
+        payload["missing_fields"] = missing_fields
+        return payload
+
     product, price_entry, currency = lookup_price(cleaned_code, cleaned_size)
     payload["currency"] = currency
+    if missing_fields:
+        payload["missing_fields"] = missing_fields
 
     if product:
         payload["product_name"] = product.get("product_name")

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -1,0 +1,26 @@
+"""Tests for utility tools that expose structured payloads."""
+
+from src.data.prices import get_currency, list_available_sizes
+from src.tools.paint import price_lookup_tool
+
+
+def test_price_lookup_requires_product_code():
+    """A missing product code should short-circuit the lookup."""
+
+    payload = price_lookup_tool("   ", "18 Ltr (Drum)")
+
+    assert payload["found"] is False
+    assert payload["requested_code"] == ""
+    assert payload["missing_fields"] == ["code"]
+    assert payload["currency"] == get_currency()
+
+
+def test_price_lookup_returns_sizes_when_size_missing():
+    """When only the size is missing, available sizes should be returned."""
+
+    payload = price_lookup_tool("A119", "")
+
+    assert payload["found"] is False
+    assert payload["missing_fields"] == ["size"]
+    assert payload["available_sizes"] == list_available_sizes("A119")
+    assert payload["currency"] == get_currency()


### PR DESCRIPTION
## Summary
- ensure the price lookup tool records missing fields before invoking the lookup
- include currency metadata for short-circuited responses
- add regression tests covering missing code and size scenarios

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68fb9a42a410832793d53d3d446505f6